### PR TITLE
Force cast cell.item instead of optional failure

### DIFF
--- a/Rugged Spot/Controllers/View Controllers/FilteredSearchViewController.swift
+++ b/Rugged Spot/Controllers/View Controllers/FilteredSearchViewController.swift
@@ -187,13 +187,13 @@ extension FilteredSearchViewController: UICollectionViewDelegate, UICollectionVi
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let cell = collectionView.cellForItem(at: indexPath) as! LabelCollectionViewCell
         
-        cell.item?.toggleSelected()
+        cell.item!.toggleSelected()
         
         switch collectionView {
         case divisionCollectionView:
-            if selectedDivision?.name != cell.item?.name {
+            if selectedDivision?.name != cell.item!.name {
                 selectedDivision?.toggleSelected()
-                selectedDivision = cell.item as? Division
+                selectedDivision = (cell.item as! Division)
                 selectedDivisionIndexPath = indexPath
             } else {
                 selectedDivision = nil
@@ -201,9 +201,9 @@ extension FilteredSearchViewController: UICollectionViewDelegate, UICollectionVi
             }
             divisionCollectionView.reloadData()
         case styleCollectionView:
-            if selectedStyle?.name != cell.item?.name {
+            if selectedStyle?.name != cell.item!.name {
                 selectedStyle?.toggleSelected()
-                selectedStyle = cell.item as? Style
+                selectedStyle = (cell.item as! Style)
                 selectedStyleIndexPath = indexPath
             } else {
                 selectedStyle = nil
@@ -211,9 +211,9 @@ extension FilteredSearchViewController: UICollectionViewDelegate, UICollectionVi
             }
             styleCollectionView.reloadData()
         case leagueCollectionView:
-            if selectedLeague?.name != cell.item?.name {
+            if selectedLeague?.name != cell.item!.name {
                 selectedLeague?.toggleSelected()
-                selectedLeague = cell.item as? League
+                selectedLeague = (cell.item as! League)
             } else {
                 selectedLeague = nil
             }

--- a/Rugged Spot/Views/LabelCollectionViewCell.swift
+++ b/Rugged Spot/Views/LabelCollectionViewCell.swift
@@ -12,7 +12,7 @@ class LabelCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet weak var defaultLabel: BorderedLabel!
     
-    var item: Selectable? {
+    var item: Selectable! {
         didSet {
             updateViews()
         }


### PR DESCRIPTION
cell.item should NEVER be nil and it being so is a case of very bad
logical error occuring somewhere. One of the danger of optionals is
always taking the easy route of letting it pass as a ? and failing
silently. You'd want this to fail immediately so you caught it during
development.

Perhaps a better option would be

    assert(cell.item != nil)
    let item = cell.item ?? Style(name: "7s") // or some other sane default